### PR TITLE
Support federation names

### DIFF
--- a/api/federation.js
+++ b/api/federation.js
@@ -1,0 +1,38 @@
+var config = require('../config');
+var response = require('response');
+var libutils = require('../lib/utils');
+
+exports.store;
+var federation = function (req, res) {
+    if (!req.query.domain || req.query.domain !== config.federation.domain) {
+        response.json({"error":"invalidParams","result":"error","error_message":"Invalid domain"}).status(400).pipe(res);
+        return;
+    }
+
+    if (!req.query.destination) {
+      if (req.query.user) { // Compatability
+          req.query.destination = req.query.user;
+      } else {
+        response.json({"error":"invalidParams","result":"error","error_message":"No destination provided"}).status(400).pipe(res);
+        return;
+      }
+    }
+
+    var normalized_username = libutils.normalizeUsername(req.query.destination);
+
+    exports.store.read({username:normalized_username,res:res},function(resp) {
+        if (resp.exists) {
+            // this is a 200
+            response.json({ federation_json: {
+                type: "federation_record",
+                destination: req.query.destination,
+                domain: config.federation.domain,
+                destination_address: resp.address
+            }}).pipe(res);
+        } else {
+            response.json({"error":"noSuchUser","result":"error","error_message":"No such alias on that domain"}).status(404).pipe(res);
+        }
+    });
+};
+
+exports.federation = federation;

--- a/api/index.js
+++ b/api/index.js
@@ -1,10 +1,12 @@
 exports.user = require('./user');
+exports.federation = require('./federation');
 exports.blob = require('./blob');
 exports.meta = require('./meta');
 exports.attestation = require('./attestation');
 
 exports.setStore = function(store) {
     exports.user.setStore(store);
+    exports.federation.store = store;
     exports.blob.setStore(store);
     exports.attestation.setStore(store);
 };

--- a/config-example.js
+++ b/config-example.js
@@ -12,6 +12,11 @@ exports.port = 8080;
 // Public URL for this blobvault (required for authinfo)
 exports.url = "https://blobvault.example.com";
 
+// Federation names provider settings
+exports.federation = {
+    domain: "example.com"
+};
+
 // SSL settings
 exports.ssl = false;
 

--- a/server.js
+++ b/server.js
@@ -49,6 +49,7 @@ app.post('/v1/lookup', api.user.batchlookup)
 app.delete('/v1/user/:username', ecdsa.middleware, api.blob.delete);
 app.get('/v1/user/:username', api.user.get);
 app.get('/v1/user/:username/verify/:token', api.user.verify);
+app.get('/v1/federation', api.federation.federation);
 
 // blob related
 app.get('/v1/blob/:blob_id', api.blob.get);


### PR DESCRIPTION
The blobvault has all of the data it needs to support federation names on a given domain, so we should support that as well as the blobvault protocol.
