### PR TITLE
[FIX] Change user read to be = instead of ILIKE

### DIFF
--- a/lib/dbcommon.js
+++ b/lib/dbcommon.js
@@ -21,28 +21,28 @@ var dbcommon = function(db) {
         var emailVerified = params.emailVerified;
         var email = params.email;
         var emailToken = params.emailToken;
-        
+
         if (emailVerified === false)
             emailVerified = 0;
-        else 
+        else
             emailVerified = 1;
-            
+
         // Convert blob from base64 to binary
         var data = new Buffer(params.data, 'base64');
         var data_size = params.data_size;
         var identity_id = libutils.generateIdentityId()
         db('blob')
         .insert({
-            id: blobId, 
-            username: username, 
+            id: blobId,
+            username: username,
             normalized_username:normalized_username,
             revision: 0,
-            address: address, 
+            address: address,
             auth_secret : authSecret,
-            data: data, 
+            data: data,
             quota:data_size,
             email_verified : emailVerified,
-            email: email, 
+            email: email,
             email_token : emailToken,
             hostlink : hostlink,
             encrypted_secret: encrypted_secret,
@@ -82,9 +82,8 @@ var dbcommon = function(db) {
         var username = params.username;
         var normalized_username = libutils.normalizeUsername(username);
         var res = params.res;
-        var operator = (config.dbtype == 'postgres') ? 'ILIKE' : 'LIKE'
         db('blob')
-        .where('normalized_username',operator,normalized_username)
+        .where('normalized_username', normalized_username)
         .select()
         .nodeify(function(err, resp) {
             if (err) {
@@ -109,7 +108,7 @@ var dbcommon = function(db) {
                     response.address = row.address;
                     response.exists = true;
                     response.recoverable = row.encrypted_blobdecrypt_key ? true : false;
-                  
+
                 } else if (config.reserved[libutils.normalizeUsername(username)]) {
                     response.exists = false;
                     response.reserved = config.reserved[libutils.normalizeUsername(username)]
@@ -134,7 +133,7 @@ var dbcommon = function(db) {
         .update(hash)
         .nodeify(function(err, resp) {
             if (err) {
-                cb({error:new Error("Database update error")}); 
+                cb({error:new Error("Database update error")});
             } else {
                 cb({result:'success'});
             }
@@ -151,10 +150,10 @@ var dbcommon = function(db) {
         db(table)
         .where(where.key,'=',where.value)
         .update(set)
-        .nodeify(function(err, resp) {  
+        .nodeify(function(err, resp) {
             if (err) {
                 reporter.log("dbcommon:update_where:error",err)
-                cb({error:new Error("Database update error")}); 
+                cb({error:new Error("Database update error")});
             } else {
                 cb({result:'success'});
             }
@@ -187,7 +186,7 @@ var dbcommon = function(db) {
         .nodeify(function(err, resp) {
             if (err) {
                 reporter.log("dbcommon:insert:error",err)
-                cb({error:new Error("Database insert error")}); 
+                cb({error:new Error("Database insert error")});
             } else {
                 cb({result:'success'});
             }
@@ -201,7 +200,7 @@ var dbcommon = function(db) {
         var where = params.where;
         var set = params.set;
         var table = params.table || 'blob';
-        if (where !== undefined) 
+        if (where !== undefined)
             db(table)
             .where(where.key,'=',where.value)
             .update(set)
@@ -214,16 +213,16 @@ var dbcommon = function(db) {
                     .insert(set)
                     .then(function() {
                         cb({result:'success'});
-                    })                 
+                    })
                 }
             })
-        else 
+        else
             db(table)
             .insert(set)
             .nodeify(function(err, resp) {
                 if (err) {
                     reporter.log("dbcommon:insert_or_update_where:error",err)
-                    cb({error:new Error("Database insert_or_update error")}); 
+                    cb({error:new Error("Database insert_or_update error")});
                 } else {
                     cb({result:'success'});
                 }
@@ -231,7 +230,7 @@ var dbcommon = function(db) {
     }
     self.insert_or_update_where = insert_or_update_where;
 
-    // readwhere returns record at where key = value 
+    // readwhere returns record at where key = value
     var read_where = function(params, cb) {
         var table = params.table || 'blob';
         var key = params.key;
@@ -242,22 +241,22 @@ var dbcommon = function(db) {
         .nodeify(function(err, resp) {
             if (err) {
                 reporter.log("READ WHEREOBJ:",err);
-                // obj is the real error, but we mask it 
-                cb({error:new Error("Database read where error")}); 
+                // obj is the real error, but we mask it
+                cb({error:new Error("Database read where error")});
             } else {
                 cb(resp)
             }
         })
     };
     self.read_where = read_where;
-    
+
     self.getAttestations = function (params, cb) {
       list = [];
       for (key in params) {
-        list.push({key:key,value:params[key]});  
+        list.push({key:key,value:params[key]});
       }
-      
-      list.reduce(function(knex, pair) { 
+
+      list.reduce(function(knex, pair) {
           return knex.andWhere(pair.key, pair.value); }, db('attestations'))
       .select()
       .nodeify(function(err, resp) {
@@ -266,9 +265,9 @@ var dbcommon = function(db) {
               } else {
                   cb(resp);
               }
-          });          
+          });
     };
-   
+
     self.getPhoneAttestation = function (identity_id, phone, cb) {
       console.log(identity_id, phone);
       db('attestations')
@@ -283,16 +282,16 @@ var dbcommon = function(db) {
         } else {
           cb(resp);
         }
-      });   
+      });
     };
-    
+
     self.blobPatch = function(size,req,res,cb) {
         db('blob')
         .where('id','=',req.body.blob_id)
         .select('id','revision')
         .nodeify(function(err, resp) {
             if (err) {
-                cb({error:new Error("Database blob patch error")}); 
+                cb({error:new Error("Database blob patch error")});
             } else {
                 var rows = resp;
                 if (rows.length) {
@@ -321,7 +320,7 @@ var dbcommon = function(db) {
                         });
                     })
                 } else {
-                    cb({error:new Error("Database blob patch error")}); 
+                    cb({error:new Error("Database blob patch error")});
                 }
             }
         })
@@ -351,7 +350,7 @@ var dbcommon = function(db) {
                                 .select('quota')
                                 .then(function(rows) {
                                     if (rows.length) {
-                                        var row = rows[0]; 
+                                        var row = rows[0];
                                         var quota = row.quota;
                                         var newquota = quota - totalsize;
                                         return db('blob')
@@ -371,8 +370,8 @@ var dbcommon = function(db) {
             .catch(function(obj) {
                 reporter.log(obj);
                 t.rollback()
-                // obj is the real error, but we mask it 
-                cb({error:new Error("Database patch consolidate error")}); 
+                // obj is the real error, but we mask it
+                cb({error:new Error("Database patch consolidate error")});
             })
         })
         .then(function() {
@@ -384,14 +383,14 @@ var dbcommon = function(db) {
 
     self.blobDelete = function(params,cb) {
       db.transaction(function(t) {
-        
+
         //get blob
         return db('blob')
         .transacting(t)
         .where('id','=',params.blob_id)
         .select()
         .then(function(resp) {
-          
+
           //get the identity_id
           if (resp.length) {
             params.identity_id = resp[0].identity_id;
@@ -403,27 +402,27 @@ var dbcommon = function(db) {
           .where('id','=',params.blob_id)
           .del()
           .then(function(){
-            
+
             //delete blob patches
             return db('blob_patches')
             .transacting(t)
             .where('blob_id','=',params.blob_id)
-            .del() 
+            .del()
             .then(function() {
-            
+
               //delete twofactor
               return db('twofactor')
               .transacting(t)
               .where('blob_id','=',params.blob_id)
-              .del() 
+              .del()
               .then(function() {
-                
+
                 //delete attestations
-                if (params.identity_id) {  
+                if (params.identity_id) {
                   return db('attestations')
                   .transacting(t)
                   .where('identity_id','=',params.identity_id)
-                  .del() 
+                  .del()
                   .then(function() {
 
                     //delete identity
@@ -431,20 +430,20 @@ var dbcommon = function(db) {
                     .transacting(t)
                     .where('id','=',params.identity_id)
                     .del();
-                  }); 
+                  });
                 }
-              });             
+              });
             });
-          });          
+          });
         });
       })
       .nodeify(function(err, resp) {
         if (err) {
           reporter.log("blobDelete: error:", err)
-          cb({error:new Error("Database blob delete error")});         
+          cb({error:new Error("Database blob delete error")});
         } else {
           reporter.log("blobDelete: transaction completed on ", params)
-          cb({result:'success'});         
+          cb({result:'success'});
         }
       });
     }
@@ -455,8 +454,8 @@ var dbcommon = function(db) {
         .nodeify(function(err, resp) {
             if (err) {
                 console.log("blobGet error:", err)
-                // obj is the real error, but we mask it 
-                cb({error:new Error("Database blob get error")}); 
+                // obj is the real error, but we mask it
+                cb({error:new Error("Database blob get error")});
             } else {
                 var rows = resp;
                 if (rows.length) {
@@ -466,7 +465,7 @@ var dbcommon = function(db) {
                     .orderBy('revision','ASC')
                     .select('data')
                     .nodeify(function(err, resp) {
-                        var rows = resp; 
+                        var rows = resp;
                         cb({
                             result: 'success',
                             encrypted_secret : blob.encrypted_secret.toString('base64'),
@@ -479,7 +478,7 @@ var dbcommon = function(db) {
                         });
                     })
                 } else {
-                    cb({error:new Error("Database blob get error")}); 
+                    cb({error:new Error("Database blob get error")});
                 }
             }
         })
@@ -490,7 +489,7 @@ var dbcommon = function(db) {
         .select()
         .nodeify(function(err, resp) {
             if (err) {
-                cb({error:new Error("IdentifyMissingFields error")}); 
+                cb({error:new Error("IdentifyMissingFields error")});
             } else {
                 var obj = {};
                 var row = resp[0];
@@ -510,8 +509,8 @@ var dbcommon = function(db) {
         .where('blob_id','=',req.params.blob_id).andWhere('revision','=',req.params.patch_id)
         .select('data')
         .catch(function(obj) {
-            // obj is the real error, but we mask it 
-            cb({error:new Error("Database get patch error")}); 
+            // obj is the real error, but we mask it
+            cb({error:new Error("Database get patch error")});
         })
         .then(function(rows) {
             if (rows.length)
@@ -520,7 +519,7 @@ var dbcommon = function(db) {
                     patch: rows[0].data.toString('base64')
                 });
             else
-                cb({error:new Error("Database get patch error")}); 
+                cb({error:new Error("Database get patch error")});
         })
     };
 
@@ -531,9 +530,9 @@ var dbcommon = function(db) {
         .where('id','=',blobId)
         .select('auth_secret')
         .catch(function(obj) {
-            // obj is the real error, but we mask it 
+            // obj is the real error, but we mask it
             reporter.log(obj);
-            cb({error:new Error("Database hmac get secret error")}); 
+            cb({error:new Error("Database hmac get secret error")});
         })
         .then(function(rows) {
             if (!rows.length) {
@@ -555,7 +554,7 @@ var dbcommon = function(db) {
         var table = params.table || 'blob';
         console.log(list);
         list
-            .reduce(function(knex, value) { 
+            .reduce(function(knex, value) {
                 return knex.orWhere(key, '=', value); }, db(table))
             .select()
             .nodeify(function(err, resp) {


### PR DESCRIPTION
Read lookup occurs on the normalized_username so performing an ILIKE is redundant since the normalization performs a toLower.
