### PR TITLE
Accept email address in authinfo, in addition to Ripple name and address

### DIFF
--- a/lib/dbcommon.js
+++ b/lib/dbcommon.js
@@ -250,6 +250,25 @@ var dbcommon = function(db) {
     };
     self.read_where = read_where;
 
+    // read_where_obj returns record at where condition is in object
+    var read_where_obj = function(params, cb) {
+        var table = params.table || 'blob';
+        var query_obj = params.obj;
+        db(table)
+        .where(query_obj)
+        .select()
+        .nodeify(function(err, resp) {
+            if (err) {
+                reporter.log('READ WHEREOBJ:', err);
+                // obj is the real error, but we mask it
+                cb({error: new Error('Database read where error')});
+            } else {
+                cb(resp);
+            }
+        });
+    };
+    self.read_where_obj = read_where_obj;
+
     self.blobPatch = function(size,req,res,cb) {
         db('blob')
         .where('id','=',req.body.blob_id)


### PR DESCRIPTION
- Description

When looking up auth information, Blobvault can take Ripple name (e.g. ~user) and Ripple address (e.g. rabc123).  This change adds one more variation - e-mail address, so that user can log in using her e-mail address.
- Design

Added logic to user.js.  If input username contains '@', we'll treat it as email address.
Added function to dbcommon.js, to support query with two WHERE conditions: match email column, and email_verified column must be true. 
